### PR TITLE
add debug functionality to SignupPage

### DIFF
--- a/Flutter/shelter_partner/lib/helper/debug.dart
+++ b/Flutter/shelter_partner/lib/helper/debug.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/foundation.dart';
+
+class DebugHelper {
+  bool debugMode;
+
+  DebugHelper({this.debugMode = kDebugMode});
+
+  bool isDebugMode() => debugMode;
+}

--- a/Flutter/shelter_partner/lib/main.dart
+++ b/Flutter/shelter_partner/lib/main.dart
@@ -1,6 +1,4 @@
-
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -79,7 +77,6 @@ class MyApp extends ConsumerWidget {
     );
   }
 }
-
 
 // Create the AuthStateChangeNotifier
 class AuthStateChangeNotifier extends ChangeNotifier {
@@ -243,9 +240,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
                 builder: (context, state) => const SettingsPage(),
                 routes: [
                   GoRoute(
-                  path: "acknowledgements",
-                  builder: (context, state) => const AcknowledgementsPage(),
-                ),
+                    path: "acknowledgements",
+                    builder: (context, state) => const AcknowledgementsPage(),
+                  ),
                   GoRoute(
                     path: 'shelter-settings',
                     builder: (context, state) => const ShelterSettingsPage(),

--- a/Flutter/shelter_partner/lib/views/auth/signup_page.dart
+++ b/Flutter/shelter_partner/lib/views/auth/signup_page.dart
@@ -3,14 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:shelter_partner/views/auth/my_button.dart';
 import 'package:shelter_partner/views/auth/my_textfield.dart';
+import 'package:uuid/uuid.dart';
+import 'package:shelter_partner/helper/debug.dart';
 
 import 'package:shelter_partner/view_models/auth_view_model.dart';
 
 class SignupPage extends ConsumerStatefulWidget {
   final void Function()? onTapLogin;
+  DebugHelper debugHelper;
 
-  const SignupPage({super.key, required this.onTapLogin});
-
+  SignupPage({super.key, required this.onTapLogin, DebugHelper? debugHelper})
+      : debugHelper = debugHelper ?? DebugHelper();
   @override
   _SignupPageState createState() => _SignupPageState();
 }
@@ -55,6 +58,24 @@ class _SignupPageState extends ConsumerState<SignupPage> {
           shelterName: shelterNameController.text.trim(),
           shelterAddress: shelterAddressController.text.trim(),
           selectedManagementSoftware: selectedManagementSoftware,
+        );
+  }
+
+  void createAndLoginTestAccount() async {
+    if (widget.debugHelper.isDebugMode() == false) {
+      return;
+    }
+    final uuid = Uuid();
+    final testEmail = '${uuid.v4()}@example.com';
+    final testPassword = 'password123';
+    await ref.read(authViewModelProvider.notifier).signup(
+          email: testEmail,
+          password: testPassword,
+          firstName: 'Test',
+          lastName: 'User',
+          shelterName: 'Test Shelter',
+          shelterAddress: '123 Test St',
+          selectedManagementSoftware: 'ShelterLuv',
         );
   }
 
@@ -138,6 +159,11 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                     title: "Create Shelter",
                     onTap: signup,
                   ),
+                  if (widget.debugHelper.isDebugMode())
+                    MyButton(
+                      title: "Create Test Account",
+                      onTap: createAndLoginTestAccount,
+                    ),
                   const SizedBox(height: 50),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,

--- a/Flutter/shelter_partner/pubspec.lock
+++ b/Flutter/shelter_partner/pubspec.lock
@@ -1001,10 +1001,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_theme_plus
-      sha256: "34824b7d9aa1b30a50be06a3355ff5abf87c29d7e97b872199586e61185d692a"
+      sha256: "5254e66f3f6b39ebf562cfe09877ea5e3af778a5a977ac187ed351414f0a15e0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.4"
+    version: "6.6.3"
   leak_tracker:
     dependency: transitive
     description:
@@ -1747,5 +1747,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
-  flutter: ">=3.24.4"
+  dart: ">=3.5.3 <4.0.0"
+  flutter: ">=3.24.3"

--- a/Flutter/shelter_partner/pubspec.yaml
+++ b/Flutter/shelter_partner/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   package_info_plus: ^8.1.0
   in_app_purchase: ^3.2.0
   flutter_launcher_icons: ^0.14.1
-  json_theme_plus: ^6.6.4
+  json_theme_plus: ^6.6.3
   infinite_scroll_pagination: ^4.0.0
 
 

--- a/Flutter/shelter_partner/test/main_test.dart
+++ b/Flutter/shelter_partner/test/main_test.dart
@@ -31,8 +31,6 @@ void main() {
 
   testWidgets('AuthPage is displayed when the app starts',
       (WidgetTester tester) async {
-    final mockFirebaseService = MockFirebaseService();
-
     await tester.pumpWidget(ProviderScope(
       overrides: [
         authRepositoryProvider.overrideWithValue(authRepository),
@@ -40,13 +38,9 @@ void main() {
       child: MyApp(
         theme: ThemeData.light(),
         darktheme: ThemeData.dark(),
-        // firebaseAuth: mockAuth,
-        // firestore: fakeFirestore,
-        // firebaseService: mockFirebaseService,
       ),
     ));
 
-    // Verify that the AuthPage is being shown initially.
     expect(find.byType(AuthPage), findsOneWidget);
   });
 }

--- a/Flutter/shelter_partner/test/signup_page_test.dart
+++ b/Flutter/shelter_partner/test/signup_page_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shelter_partner/views/auth/signup_page.dart';
+import 'package:shelter_partner/helper/debug.dart';
+
+void main() {
+  testWidgets('Create Test Account button is not visible in release mode',
+      (WidgetTester tester) async {
+    final debugHelper = DebugHelper(debugMode: false);
+
+    await tester.pumpWidget(ProviderScope(
+      child: MaterialApp(
+        home: SignupPage(onTapLogin: () {}, debugHelper: debugHelper),
+      ),
+    ));
+
+    expect(find.text('Create Test Account'), findsNothing);
+  });
+
+  testWidgets('Create Test Account button is visible in debug mode',
+      (WidgetTester tester) async {
+    final debugHelper = DebugHelper(debugMode: true);
+
+    await tester.pumpWidget(ProviderScope(
+      child: MaterialApp(
+        home: SignupPage(onTapLogin: () {}, debugHelper: debugHelper),
+      ),
+    ));
+
+    expect(find.text('Create Test Account'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Introduce a DebugHelper class to enable debug mode features in the SignupPage.

The new 'Create Test Account' button is only visible in debug mode. 
https://youtu.be/JAfr8jqig1A