### PR TITLE
Added location tiers and dummy fullLocation

### DIFF
--- a/Flutter/shelter_partner/lib/models/animal.dart
+++ b/Flutter/shelter_partner/lib/models/animal.dart
@@ -34,6 +34,12 @@ class Animal {
   final List<Log> logs;
   final List<Tag> tags;
 
+  List<String> get locationTiers {
+    return fullLocation != 'Unknown'
+        ? fullLocation.split('>').map((tier) => tier.trim()).toList()
+        : [];
+  }
+
   Animal({
     required this.id,
     required this.name,
@@ -62,34 +68,45 @@ class Animal {
   });
 
   factory Animal.fromFirestore(Map<String, dynamic> data, String documentId) {
-  return Animal(
-    id: documentId,
-    name: data['name'] ?? 'Unknown',
-    sex: data['sex'] ?? 'Unknown',
-    monthsOld: data['monthsOld'] ?? 0,
-    species: data['species'] ?? 'Unknown',
-    breed: data['breed'] ?? 'Unknown',
-    location: data['location'] ?? 'Unknown',
-    fullLocation: data['fullLocation'] ?? 'Unknown',
-    description: data['description'] ?? 'No description available.',
-    symbol: data['symbol'] ?? 'tag',
-    symbolColor: data['symbolColor'] ?? '',
-    takeOutAlert: data['takeOutAlert'] ?? 'Unknown',
-    putBackAlert: data['putBackAlert'] ?? 'Unknown',
-    adoptionCategory: data['adoptionCategory'] ?? 'Unknown',
-    behaviorCategory: data['behaviorCategory'] ?? 'Unknown',
-    locationCategory: data['locationCategory'] ?? 'Unknown',
-    medicalCategory: data['medicalCategory'] ?? 'Unknown',
-    volunteerCategory: data['volunteerCategory'] ?? 'Unknown',
-    inKennel: data['inKennel'] ?? true,
-    intakeDate: data['intakeDate'],
-    photos: (data['photos'] is List) ? (data['photos'] as List).map((photo) => Photo.fromMap(photo)).toList() : [],
-    notes: (data['notes'] is List) ? (data['notes'] as List).map((note) => Note.fromMap(note)).toList() : [],
-    logs: (data['logs'] is List) ? (data['logs'] as List).map((log) => Log.fromMap(log)).toList() : [],
-    tags: (data['tags'] is List) ? (data['tags'] as List).map((tag) => Tag.fromMap(tag)).toList() : [],
-  );
-}
+    final fullLocation = data['fullLocation'] ?? 'Unknown';
 
+    return Animal(
+      id: documentId,
+      name: data['name'] ?? 'Unknown',
+      sex: data['sex'] ?? 'Unknown',
+      monthsOld: data['monthsOld'] ?? 0,
+      species: data['species'] ?? 'Unknown',
+      breed: data['breed'] ?? 'Unknown',
+      location: data['location'] ?? 'Unknown',
+      fullLocation: fullLocation,
+      description: data['description'] ?? 'No description available.',
+      symbol: data['symbol'] ?? 'tag',
+      symbolColor: data['symbolColor'] ?? '',
+      takeOutAlert: data['takeOutAlert'] ?? 'Unknown',
+      putBackAlert: data['putBackAlert'] ?? 'Unknown',
+      adoptionCategory: data['adoptionCategory'] ?? 'Unknown',
+      behaviorCategory: data['behaviorCategory'] ?? 'Unknown',
+      locationCategory: data['locationCategory'] ?? 'Unknown',
+      medicalCategory: data['medicalCategory'] ?? 'Unknown',
+      volunteerCategory: data['volunteerCategory'] ?? 'Unknown',
+      inKennel: data['inKennel'] ?? true,
+      intakeDate: data['intakeDate'],
+      photos: (data['photos'] is List)
+          ? (data['photos'] as List)
+              .map((photo) => Photo.fromMap(photo))
+              .toList()
+          : [],
+      notes: (data['notes'] is List)
+          ? (data['notes'] as List).map((note) => Note.fromMap(note)).toList()
+          : [],
+      logs: (data['logs'] is List)
+          ? (data['logs'] as List).map((log) => Log.fromMap(log)).toList()
+          : [],
+      tags: (data['tags'] is List)
+          ? (data['tags'] as List).map((tag) => Tag.fromMap(tag)).toList()
+          : [],
+    );
+  }
 
   // Add copyWith method
   Animal copyWith({
@@ -145,8 +162,7 @@ class Animal {
       tags: tags ?? this.tags,
     );
   }
-  
-  // Add toMap method
+
   Map<String, dynamic> toMap() {
     return {
       'id': id,

--- a/Flutter/shelter_partner/lib/repositories/auth_repository.dart
+++ b/Flutter/shelter_partner/lib/repositories/auth_repository.dart
@@ -157,7 +157,6 @@ class AuthRepository {
       buttonType: 'In App',
       appendAnimalDataToURL: false,
       removeAds: true,
-
       simplisticMode: true,
     );
 
@@ -166,11 +165,9 @@ class AuthRepository {
       'email': email.trim(),
       'firstName': firstName.trim(),
       'lastName': lastName.trim(),
-
       'lastActivity': Timestamp.now(),
       'averageLogDuration': 0,
       'totalTimeLoggedWithAnimals': 0,
-
       'shelterID': shelterId,
       'type': 'admin',
       'accountSettings': defaultAccountSettings.toMap(),
@@ -232,7 +229,7 @@ class AuthRepository {
         createLogsWhenUnderMinimumDuration: false,
         showCustomForm: false,
         customFormURL: "",
-        appendAnimalDataToURL: true,  
+        appendAnimalDataToURL: true,
         // Create default geofence
         geofence: Geofence(
           location: const GeoPoint(43.0722, -89.4008),
@@ -310,14 +307,8 @@ class AuthRepository {
               : collectionName == 'cats'
                   ? 'cat'
                   : 'Unknown',
-          'symbolColor': [
-            'red',
-            'green',
-            'blue',
-            'yellow',
-            'orange',
-            'purple'
-          ].randomElement(),
+          'symbolColor': ['red', 'green', 'blue', 'yellow', 'orange', 'purple']
+              .randomElement(),
           'symbol': 'pets', // Example static value, adjust as needed
           'volunteerCategory': ['Red', 'Green', 'Blue'].randomElement(),
           'locationCategory':
@@ -335,6 +326,12 @@ class AuthRepository {
           'id': animalId,
           'inKennel': true,
           'location': row['location'] ?? '',
+          'fullLocation':
+              '${row['location'] ?? 'Site 1'} > Building ${Random().nextInt(3) + 1} > Room ${[
+            'A',
+            'B',
+            'C'
+          ].randomElement()} > Kennel ${Random().nextInt(20) + 1}',
           'name': row['name'] ??
               'Unknown', // Default to 'Unknown' if name is missing
           'startTime':

--- a/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
+++ b/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
@@ -38,8 +38,10 @@ String _timeAgo(DateTime dateTime, bool inKennel) {
 
 class AnimalCardView extends ConsumerStatefulWidget {
   final Animal animal;
+  final int maxLocationTiers;
 
-  const AnimalCardView({super.key, required this.animal});
+  const AnimalCardView(
+      {super.key, required this.animal, required this.maxLocationTiers});
 
   @override
   _AnimalCardViewState createState() => _AnimalCardViewState();
@@ -55,13 +57,13 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
   @override
   void initState() {
     super.initState();
-    
+
     // Print the account type on appear.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final appUser = ref.read(appUserProvider);
       print("Account type on appear: ${appUser?.type}");
     });
-    
+
     // Handle automatic put back after the first frame.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_automaticPutBackHandled) {
@@ -101,23 +103,29 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
         final currentAnimal = widget.animal;
         print("DEBUG: currentAnimal.inKennel: ${currentAnimal.inKennel}");
         if (currentAnimal.inKennel) {
-          final accountDetails = ref.read(accountSettingsViewModelProvider).value;
+          final accountDetails =
+              ref.read(accountSettingsViewModelProvider).value;
           print("DEBUG: accountDetails: $accountDetails");
           if (accountDetails != null) {
             final appUser = ref.read(appUserProvider);
             print("DEBUG: appUser: $appUser");
-            final shelterSettings = ref.read(shelterDetailsViewModelProvider).value;
+            final shelterSettings =
+                ref.read(shelterDetailsViewModelProvider).value;
             print("DEBUG: shelterSettings: $shelterSettings");
             bool requireName;
             bool requireLetOutType;
             if (appUser?.type == "admin") {
               requireName = accountDetails.accountSettings!.requireName;
-              requireLetOutType = accountDetails.accountSettings!.requireLetOutType;
-              print("DEBUG: Admin account - requireName: $requireName, requireLetOutType: $requireLetOutType");
+              requireLetOutType =
+                  accountDetails.accountSettings!.requireLetOutType;
+              print(
+                  "DEBUG: Admin account - requireName: $requireName, requireLetOutType: $requireLetOutType");
             } else {
               requireName = shelterSettings!.volunteerSettings.requireName;
-              requireLetOutType = shelterSettings.volunteerSettings.requireLetOutType;
-              print("DEBUG: Volunteer account - requireName: $requireName, requireLetOutType: $requireLetOutType");
+              requireLetOutType =
+                  shelterSettings.volunteerSettings.requireLetOutType;
+              print(
+                  "DEBUG: Volunteer account - requireName: $requireName, requireLetOutType: $requireLetOutType");
             }
             if (requireName || requireLetOutType) {
               print("DEBUG: Showing take out confirmation dialog");
@@ -125,7 +133,8 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
             } else {
               print("DEBUG: Directly taking out animal");
               ref
-                  .read(takeOutConfirmationViewModelProvider(widget.animal).notifier)
+                  .read(takeOutConfirmationViewModelProvider(widget.animal)
+                      .notifier)
                   .takeOutAnimal(
                     widget.animal,
                     Log(
@@ -143,7 +152,8 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
             print("DEBUG: accountDetails is null");
           }
         } else {
-          print("DEBUG: Animal not in kennel, showing put back confirmation dialog");
+          print(
+              "DEBUG: Animal not in kennel, showing put back confirmation dialog");
           _showPutBackConfirmationDialog();
         }
       }
@@ -219,7 +229,8 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
     );
 
     return Card(
-      color: animal.inKennel ? Colors.lightBlue.shade100 : Colors.orange.shade100,
+      color:
+          animal.inKennel ? Colors.lightBlue.shade100 : Colors.orange.shade100,
       elevation: 1,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(25),
@@ -357,6 +368,17 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
                               icon: Icons.location_on,
                               label: animal.location,
                             ),
+                          if (animal.locationTiers.isNotEmpty)
+                            for (var tier in animal.locationTiers.sublist(
+                              animal.locationTiers.length > 1
+                                  ? animal.locationTiers.length -
+                                      widget.maxLocationTiers
+                                  : animal.locationTiers.length,
+                            ))
+                              _buildInfoChip(
+                                icon: Icons.location_on,
+                                label: tier,
+                              ),
                           if (animal.adoptionCategory.isNotEmpty)
                             _buildInfoChip(
                               icon: Icons.shopping_bag,

--- a/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
+++ b/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
@@ -363,11 +363,11 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
                         spacing: 4,
                         runSpacing: 4,
                         children: [
-                          if (animal.location.isNotEmpty)
-                            _buildInfoChip(
-                              icon: Icons.location_on,
-                              label: animal.location,
-                            ),
+                          // if (animal.location.isNotEmpty)
+                          //   _buildInfoChip(
+                          //     icon: Icons.location_on,
+                          //     label: animal.location,
+                          //   ),
                           if (animal.locationTiers.isNotEmpty)
                             for (var tier in animal.locationTiers.sublist(
                               animal.locationTiers.length > 1

--- a/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
+++ b/Flutter/shelter_partner/lib/views/components/animal_card_view.dart
@@ -363,11 +363,12 @@ class _AnimalCardViewState extends ConsumerState<AnimalCardView>
                         spacing: 4,
                         runSpacing: 4,
                         children: [
-                          // if (animal.location.isNotEmpty)
-                          //   _buildInfoChip(
-                          //     icon: Icons.location_on,
-                          //     label: animal.location,
-                          //   ),
+                          if (animal.location.isNotEmpty &&
+                              animal.locationTiers.isEmpty)
+                            _buildInfoChip(
+                              icon: Icons.location_on,
+                              label: animal.location,
+                            ),
                           if (animal.locationTiers.isNotEmpty)
                             for (var tier in animal.locationTiers.sublist(
                               animal.locationTiers.length > 1

--- a/Flutter/shelter_partner/lib/views/pages/enrichment_page.dart
+++ b/Flutter/shelter_partner/lib/views/pages/enrichment_page.dart
@@ -44,6 +44,8 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
   // State variables for search and attribute selection
   final TextEditingController _searchController = TextEditingController();
   String searchQuery = '';
+  int selectedLocationTierCount = 2; // Default to 2 location tiers
+  final List<int> locationTierOptions = [1, 2, 3, 4];
 
   // For attribute dropdown
   String selectedAttributeDisplayName = 'Name'; // Default display name
@@ -97,7 +99,6 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
     _catsPagingController.addPageRequestListener((pageKey) {
       _fetchPage(animalType: 'cats', pageKey: pageKey);
     });
-
 
     _tabController.addListener(() {
       setState(() {});
@@ -230,7 +231,6 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
         isActive ? "Active" : "Inactive";
   }
 
-
   Future<void> _fetchPage({
     required String animalType,
     required int pageKey,
@@ -312,7 +312,9 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
                         true) {
                       return SimplisticAnimalCardView(animal: item);
                     } else {
-                      return AnimalCardView(animal: item);
+                      return AnimalCardView(
+                          animal: item,
+                          maxLocationTiers: selectedLocationTierCount);
                     }
                   } else if (item is Ad) {
                     return CustomAffiliateAd(ad: item);
@@ -403,7 +405,9 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
                                 .value!.accountSettings?.simplisticMode ??
                             true
                         ? SimplisticAnimalCardView(animal: animal)
-                        : AnimalCardView(animal: animal);
+                        : AnimalCardView(
+                            animal: animal,
+                            maxLocationTiers: selectedLocationTierCount);
                   },
                 ),
               ],
@@ -550,6 +554,7 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
                               ),
                             ),
                             const SizedBox(width: 8),
+
                             // Attribute dropdown
                             DropdownButton<String>(
                               value: selectedAttributeDisplayName,
@@ -573,6 +578,54 @@ class _EnrichmentPageState extends ConsumerState<EnrichmentPage>
                             ),
                           ],
                         ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            const Text(
+                              'No. of location tiers shown:',
+                              style: TextStyle(
+                                  fontSize: 16, fontWeight: FontWeight.w500),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  border: Border(
+                                    bottom: BorderSide(
+                                        color: Colors.grey, width: 1.5),
+                                  ),
+                                ),
+                                child: DropdownButtonHideUnderline(
+                                  child: DropdownButton<int>(
+                                    value: selectedLocationTierCount,
+                                    isExpanded: true,
+                                    onChanged: (int? newValue) {
+                                      if (newValue != null) {
+                                        setState(() {
+                                          selectedLocationTierCount = newValue;
+                                          _dogsPagingController.refresh();
+                                          _catsPagingController.refresh();
+                                        });
+                                      }
+                                    },
+                                    style: const TextStyle(
+                                        fontSize: 16, color: Colors.black),
+                                    items: locationTierOptions
+                                        .map<DropdownMenuItem<int>>(
+                                            (int value) {
+                                      return DropdownMenuItem<int>(
+                                        value: value,
+                                        child: Text(
+                                            'Last $value tier${value > 1 ? 's' : ''}'),
+                                      );
+                                    }).toList(),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+
                         const SizedBox(height: 8),
                         Padding(
                           padding: const EdgeInsets.symmetric(
@@ -893,14 +946,15 @@ class _CustomAffiliateAdState extends State<CustomAffiliateAd>
 
   @override
   Widget build(BuildContext context) {
-
     final resizedImages = _imageUrls.map((url) {
-      final proxyUrl = 'https://cors-images-222422545919.us-central1.run.app?url=${Uri.encodeComponent(url)}';
+      final proxyUrl =
+          'https://cors-images-222422545919.us-central1.run.app?url=${Uri.encodeComponent(url)}';
       return CachedNetworkImage(
         imageUrl: proxyUrl,
         cacheKey: url,
         fit: BoxFit.cover,
-        placeholder: (context, url) => const Center(child: CircularProgressIndicator()),
+        placeholder: (context, url) =>
+            const Center(child: CircularProgressIndicator()),
         errorWidget: (context, url, error) => const Icon(Icons.error),
       );
     }).toList();

--- a/Flutter/shelter_partner/pubspec.lock
+++ b/Flutter/shelter_partner/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   adaptive_number:
     dependency: transitive
     description:
@@ -34,10 +34,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -282,10 +282,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -953,18 +953,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1001,10 +1001,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -1321,7 +1321,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   sliver_tools:
     dependency: transitive
     description:
@@ -1398,10 +1398,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1430,10 +1430,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   synchronized:
     dependency: transitive
     description:
@@ -1454,10 +1454,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   timing:
     dependency: transitive
     description:
@@ -1566,10 +1566,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:

--- a/Website/pubspec.lock
+++ b/Website/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -84,18 +84,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -156,7 +156,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -169,10 +169,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -185,10 +185,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -201,10 +201,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
@JaredDanielJones Donee..! Let me know if there are some issues, the current changes will automatically manage dummy fullLocations for new accounts only cause I have changed the auth_repository.dart to manage that in the accounts created from now on, I don't know how can I manage for the accounts already created. I have used fullLocation value from firebase to create locationTiers in frontend rather than creating a new LocationTiers attribute in backend, I guess it will keep the backend simpler and allow us achieve our motive too. Whenever we will need to modify anything regarding locationTiers, we can easily manage that too by adding a logic to change fullLocation accordingly. Also, the option for choosing how many tiers to be shown has been added in the additional options to provide more customizations.
Please review and let me know if any changes required.